### PR TITLE
Fix image format to match editor.js v2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,6 +49,8 @@ GEM
       nokogiri (>= 1.5.9)
     method_source (0.9.2)
     minitest (5.14.4)
+    nokogiri (1.12.3-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.12.3-x86_64-darwin)
       racc (~> 1.4)
     parallel (1.20.1)
@@ -104,6 +106,7 @@ GEM
     zeitwerk (2.4.2)
 
 PLATFORMS
+  arm64-darwin-20
   x86_64-darwin-20
 
 DEPENDENCIES

--- a/lib/editor_js/blocks/image_block.rb
+++ b/lib/editor_js/blocks/image_block.rb
@@ -11,8 +11,14 @@ module EditorJs
           properties:
             caption:
               type: string
-            url:
-              type: string
+            file:
+              type: object
+              additionalProperties: true
+              properties:
+                url:
+                  type: string
+              required:
+              - url
             stretched:
               type: boolean
             withBackground:
@@ -20,13 +26,13 @@ module EditorJs
             withBorder:
               type: boolean
           required:
-          - url
+          - file
         YAML
       end
 
       def render(_options = {})
         content_tag :div, class: css_name do
-          url = data['url']
+          url = data.dig('file', 'url')
           caption = data['caption']
           withBorder = data['withBorder']
           withBackground = data['withBackground']
@@ -45,13 +51,11 @@ module EditorJs
       end
 
       def sanitize!
-        %w[caption url].each do |key|
-          str = Sanitize.fragment(data[key], remove_contents: true).strip
-          if key == 'url'
-            str.gsub!('&amp;', '&')
-          end
-          data[key] = str
-        end
+        data['caption'] = Sanitize.fragment(data['caption'], remove_contents: true).strip
+        data['file'] ||= {}
+        url = Sanitize.fragment(data.dig('file', 'url'), remove_contents: true).strip
+        url.gsub!('&amp;', '&')
+        data['file']['url'] = url
       end
 
       def plain

--- a/spec/data/document_1.json
+++ b/spec/data/document_1.json
@@ -17,7 +17,9 @@
         {
             "type": "qiniuImage",
             "data": {
-                "url": "http://assets.wedxt.com/1576659125484-%E5%B1%8F%E5%B9%95%E5%BF%AB%E7%85%A7%202019-10-15%2021.34.57.png",
+                "file": {
+                  "url": "http://assets.wedxt.com/1576659125484-%E5%B1%8F%E5%B9%95%E5%BF%AB%E7%85%A7%202019-10-15%2021.34.57.png"
+                },
                 "caption": "",
                 "withBorder": false,
                 "withBackground": false,

--- a/spec/data/document_1.output
+++ b/spec/data/document_1.output
@@ -17,7 +17,9 @@
       {
             "type": "qiniuImage",
             "data": {
-                "url": "http://assets.wedxt.com/1576659125484-%E5%B1%8F%E5%B9%95%E5%BF%AB%E7%85%A7%202019-10-15%2021.34.57.png",
+                "file": {
+                  "url": "http://assets.wedxt.com/1576659125484-%E5%B1%8F%E5%B9%95%E5%BF%AB%E7%85%A7%202019-10-15%2021.34.57.png"
+                },
                 "caption": "",
                 "withBorder": false,
                 "withBackground": false,

--- a/spec/editor_js/blocks/image_block_spec.rb
+++ b/spec/editor_js/blocks/image_block_spec.rb
@@ -5,7 +5,9 @@ RSpec.describe EditorJs::Blocks::ImageBlock do
     {
       type: 'image',
       data: {
-        url: 'http://xxx/image.png',
+        file: {
+          url: 'http://xxx/image.png'
+        },
         caption: 'this is a <b>caption</b> &lt;hello&gt; world',
         withBorder: false,
         withBackground: false,
@@ -22,5 +24,4 @@ RSpec.describe EditorJs::Blocks::ImageBlock do
     it { expect(image.render).to eq(%|<div class="editor_js--image"><div class="editor_js--image__picture"><img src="http://xxx/image.png"></img></div><div class="editor_js--image__caption">this is a  &lt;hello&gt; world</div></div>|) }
     it { expect(image.plain).to eq('this is a  <hello> world') }
   end
-
 end

--- a/spec/editor_js/blocks/qiniu_image_block_spec.rb
+++ b/spec/editor_js/blocks/qiniu_image_block_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe EditorJs::Blocks::QiniuImageBlock do
     {
       type: 'qiniu_image',
       data: {
-        url: 'http://xxx/image.png',
+        file: { url: 'http://xxx/image.png' },
         caption: '七牛<b>图片</b>2&lt;/div&gt;<small>text code</small>',
         withBorder: true,
         withBackground: false,
@@ -18,7 +18,7 @@ RSpec.describe EditorJs::Blocks::QiniuImageBlock do
     {
       type: 'qiniu_image',
       data: {
-        url: 'http://xxx/image2.png',
+        file: { url: 'http://xxx/image2.png' },
         caption: '七牛<b>图片</b>2&lt;/div&gt;<small>text code2</small>',
         withBorder: true,
         withBackground: true,
@@ -31,7 +31,7 @@ RSpec.describe EditorJs::Blocks::QiniuImageBlock do
     {
       type: 'qiniu_image',
       data: {
-        url: 'http://xxx/image3.png',
+        file: { url: 'http://xxx/image3.png' },
         caption: '七牛<b>图片</b>2&lt;/div&gt;<small>text code3</small>',
         withBorder: false,
         withBackground: false,
@@ -44,7 +44,7 @@ RSpec.describe EditorJs::Blocks::QiniuImageBlock do
     {
       type: 'qiniuImage',
       data: {
-        url: 'http://xxx/f.image4.png',
+        file: { url: 'http://xxx/f.image4.png' },
         caption: '七牛<b>图片</b>4&lt;/div&gt;<small>text code3</small>',
         withBorder: true,
         withBackground: true,


### PR DESCRIPTION
@editorjs/image formats the image url inside a node named file e.g. 

```
file: {
  url: 'url'
}
```